### PR TITLE
fix: Blank TextView of repo's desc, when desc is null

### DIFF
--- a/app/src/main/java/com/openci/ui/fragments/PrivateReposFragment.java
+++ b/app/src/main/java/com/openci/ui/fragments/PrivateReposFragment.java
@@ -121,7 +121,13 @@ public class PrivateReposFragment extends Fragment {
 
             RepoResponse repo = repos.get(position);
             holder.slug.setText(repo.getSlug());
-            holder.description.setText(repo.getDescription());
+
+            if(repo.getDescription() == null || repo.getDescription().length() == 0 || repo.getDescription().equals("")) {
+                holder.description.setVisibility(View.GONE);
+            }
+            else {
+                holder.description.setText(repo.getDescription());
+            }
 
             ReposDefaultBranch reposDefaultBranch = repo.getReposDefualtBranch();
             holder.branch.setText(reposDefaultBranch.getName());

--- a/app/src/main/java/com/openci/ui/fragments/PublicReposFragment.java
+++ b/app/src/main/java/com/openci/ui/fragments/PublicReposFragment.java
@@ -122,7 +122,13 @@ public class PublicReposFragment extends Fragment {
 
             RepoResponse repo = repos.get(position);
             holder.slug.setText(repo.getSlug());
-            holder.description.setText(repo.getDescription());
+
+            if(repo.getDescription() == null || repo.getDescription().length() == 0 || repo.getDescription().equals("")) {
+                holder.description.setVisibility(View.GONE);
+            }
+            else {
+                holder.description.setText(repo.getDescription());
+            }
 
             ReposDefaultBranch reposDefaultBranch = repo.getReposDefualtBranch();
             holder.branch.setText(reposDefaultBranch.getName());


### PR DESCRIPTION
Fixes #5.

Changes: When there is no description of the repo is `null`, hide it's TextView to prevent displaying blank space.

