### PR TITLE
App logout fixed

### DIFF
--- a/app/src/main/java/com/openci/core/DrawerNavigator.java
+++ b/app/src/main/java/com/openci/core/DrawerNavigator.java
@@ -8,6 +8,7 @@ import android.view.MenuItem;
 
 import com.openci.R;
 import com.openci.ui.activities.LoginActivity;
+import com.openci.ui.activities.MainActivity;
 
 import static android.content.Context.MODE_PRIVATE;
 
@@ -64,5 +65,6 @@ public class DrawerNavigator {
         editor.commit();
         Intent intentToLoginActivity = new Intent(context, LoginActivity.class);
         context.startActivity(intentToLoginActivity);
+        ((MainActivity) context).finishAffinity();
     }
 }


### PR DESCRIPTION
Fixes #29 
Changes: 
All the activities open before the login activity are closed. 

Screenshots/GIF for the change: 
![](https://media.giphy.com/media/8lHcPWqs70xBzQFgj7/giphy.gif)
